### PR TITLE
Fix class name bug in chat and server start script

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -43,10 +43,10 @@
  function chatStripe (isAi, value, uniqueId) {
     return (
         `
-            <div class="wrapper ${isAi && 'ai'}">
+            <div class="wrapper ${isAi ? 'ai' : ''}">
                 <div class="chat">
                     <div class="profile">
-                        <img 
+                        <img
                             src="${isAi ? bot : user}"
                             alt="${isAi ? 'bot' : 'user'}"
                         />

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "server": "nodemon server"
+    "server": "nodemon server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- fix wrong `wrapper` class logic so user chats don't get `false` as a class
- correct nodemon command in `server/package.json`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd client && npm test` *(fails: Missing script: "test")*
- `cd ../server && npm test` *(fails: Missing script: "test")*